### PR TITLE
UPS-1926: Add 'all' option to activity date picker.

### DIFF
--- a/app/scripts/activity/activity.service.js
+++ b/app/scripts/activity/activity.service.js
@@ -33,10 +33,14 @@ function activityService($q, $http, $rootScope, appConfig, Activity) {
     /*jshint camelcase: false */
     var requestParameters = {
       query: searchParameters.query,
-      date_type: searchParameters.dateRange.value,
       page: searchParameters.page,
       limit: searchParameters.limit
     };
+
+    // Only add daterange value if it's meaningful.
+    if (searchParameters.dateRange.value !== 'all') {
+      requestParameters['date_type'] = searchParameters.dateRange.value;
+    }
 
     var searchRequest = $http.get(
         apiUrl + 'passholders/' + passholder.passNumber + '/activities',

--- a/app/scripts/activity/activity.service.js
+++ b/app/scripts/activity/activity.service.js
@@ -12,8 +12,9 @@ angular
   .service('activityService', activityService);
 
 /* @ngInject */
-function activityService($q, $http, $rootScope, appConfig, Activity) {
+function activityService($q, $http, $rootScope, appConfig, Activity, DateRange) {
   var apiUrl = appConfig.apiUrl;
+  var dateRanges = angular.copy(DateRange);
 
   /*jshint validthis: true */
   var service = this;
@@ -38,7 +39,7 @@ function activityService($q, $http, $rootScope, appConfig, Activity) {
     };
 
     // Only add daterange value if it's meaningful.
-    if (searchParameters.dateRange.value !== 'all') {
+    if (searchParameters.dateRange.value !== dateRanges.ALL.value) {
       requestParameters['date_type'] = searchParameters.dateRange.value;
     }
 

--- a/app/scripts/utilities/date-range.constant.js
+++ b/app/scripts/utilities/date-range.constant.js
@@ -34,6 +34,10 @@ angular
       label: 'Volgende 12 maanden',
       value: 'next_12_months'
     },
+    'ALL': {
+      label: 'Alle activiteiten',
+      value: 'all'
+    },
     'PAST': {
       label: 'Afgelopen activiteiten ',
       value: 'past'

--- a/app/views/activity/content-activities.html
+++ b/app/views/activity/content-activities.html
@@ -21,10 +21,10 @@
           <li role="menuitem">
             <a href ng-click="ac.updateDateRange(ac.dateRanges.NEXT_12_MONTHS)">Volgende 12 maanden</a>
           </li>
-          <li class="divider"></li>
           <li role="menuitem">
             <a href ng-click="ac.updateDateRange(ac.dateRanges.ALL)">Alle activiteiten</a>
           </li>
+          <li class="divider"></li>
           <li role="menuitem">
             <a href ng-click="ac.updateDateRange(ac.dateRanges.PAST)">Afgelopen activiteiten</a>
           </li>

--- a/app/views/activity/content-activities.html
+++ b/app/views/activity/content-activities.html
@@ -23,6 +23,9 @@
           </li>
           <li class="divider"></li>
           <li role="menuitem">
+            <a href ng-click="ac.updateDateRange(ac.dateRanges.ALL)">Alle activiteiten</a>
+          </li>
+          <li role="menuitem">
             <a href ng-click="ac.updateDateRange(ac.dateRanges.PAST)">Afgelopen activiteiten</a>
           </li>
         </ul>

--- a/app/views/group/activities.html
+++ b/app/views/group/activities.html
@@ -21,10 +21,10 @@
           <li role="menuitem">
             <a href ng-click="ac.updateDateRange(ac.dateRanges.NEXT_12_MONTHS)">Volgende 12 maanden</a>
           </li>
-          <li class="divider"></li>
           <li role="menuitem">
             <a href ng-click="ac.updateDateRange(ac.dateRanges.ALL)">Alle activiteiten</a>
           </li>
+          <li class="divider"></li>
           <li role="menuitem">
             <a href ng-click="ac.updateDateRange(ac.dateRanges.PAST)">Afgelopen activiteiten</a>
           </li>

--- a/app/views/group/activities.html
+++ b/app/views/group/activities.html
@@ -23,6 +23,9 @@
           </li>
           <li class="divider"></li>
           <li role="menuitem">
+            <a href ng-click="ac.updateDateRange(ac.dateRanges.ALL)">Alle activiteiten</a>
+          </li>
+          <li role="menuitem">
             <a href ng-click="ac.updateDateRange(ac.dateRanges.PAST)">Afgelopen activiteiten</a>
           </li>
         </ul>

--- a/test/spec/activity/activity.service.spec.js
+++ b/test/spec/activity/activity.service.spec.js
@@ -171,6 +171,25 @@ describe('Service: activity', function (){
     $httpBackend.flush();
   });
 
+  it('should not use a date_type query argument when searching "all"', function (done) {
+    var passholder = { passNumber: '01234567891234', points: 123 };
+    var searchParameters = {
+      query: '',
+      dateRange: DateRange.ALL,
+      page: 1,
+      limit: 5
+    };
+    $httpBackend
+      .expectGET(apiUrl + 'passholders/' + passholder.passNumber + '/activities?limit=5&page=1&query=')
+      .respond(200, JSON.stringify(pagedActivityData));
+
+    activityService
+      .search(passholder, searchParameters)
+      .then(done);
+
+    $httpBackend.flush();
+  });
+
   it ('throws an error when it can\'t get a list of activities', function (done) {
     var passholder = { passNumber: '01234567891234', points: 123 };
     var searchParameters = {

--- a/test/spec/activity/activity.service.spec.js
+++ b/test/spec/activity/activity.service.spec.js
@@ -15,6 +15,9 @@ describe('Service: activity', function (){
 
   var $scope, $q, $rootScope, $httpBackend, activityService, DateRange, Activity;
 
+  var hourMs = 60 * 60 * 1000;
+  var now = new Date();
+
   var pagedActivityData = {
     '@context': 'http://www.w3.org/ns/hydra/context.jsonld',
     '@type': 'PagedCollection',
@@ -30,8 +33,8 @@ describe('Service: activity', function (){
         'points': 182,
         'checkinConstraint': {
           'allowed': true,
-          'startDate': '2015-09-01T00:00:00+00:00',
-          'endDate': '2015-09-01T23:59:59+00:00',
+          'startDate': now.toISOString(),
+          'endDate': (new Date(now.getTime() + hourMs)).toISOString(),
           'reason': ''
         },
         'free': false
@@ -45,8 +48,8 @@ describe('Service: activity', function (){
         'points': 182,
         'checkinConstraint': {
           'allowed': true,
-          'startDate': '2015-09-01T00:00:00+00:00',
-          'endDate': '2015-09-01T23:59:59+00:00',
+          'startDate': now.toISOString(),
+          'endDate': (new Date(now.getTime() + hourMs)).toISOString(),
           'reason': ''
         },
         'free': true
@@ -66,8 +69,8 @@ describe('Service: activity', function (){
       'points': 182,
       'checkinConstraint': {
         'allowed': true,
-        'startDate': '2015-09-01T00:00:00+00:00',
-        'endDate': '2015-09-01T23:59:59+00:00',
+          'startDate': now.toISOString(),
+          'endDate': (new Date(now.getTime() + hourMs)).toISOString(),
         'reason': ''
       },
       free: true,
@@ -131,8 +134,8 @@ describe('Service: activity', function (){
           'points': 182,
           'checkinConstraint': {
             'allowed': true,
-            'startDate': new Date('2015-09-01T00:00:00+00:00'),
-            'endDate': new Date('2015-09-01T23:59:59+00:00'),
+            'startDate': now,
+            'endDate': new Date(now.getTime() + hourMs),
             'reason': ''
           },
           'free': false
@@ -146,8 +149,8 @@ describe('Service: activity', function (){
           'points': 182,
           'checkinConstraint': {
             'allowed': true,
-            'startDate': new Date('2015-09-01T00:00:00+00:00'),
-            'endDate': new Date('2015-09-01T23:59:59+00:00'),
+            'startDate': now,
+            'endDate': new Date(now.getTime() + hourMs),
             'reason': ''
           },
           'free': true
@@ -210,8 +213,8 @@ describe('Service: activity', function (){
       'points': 182,
       'checkinConstraint': {
         'allowed': true,
-        'startDate': new Date('2015-09-01T00:00:00+00:00'),
-        'endDate': new Date('2015-09-01T23:59:59+00:00'),
+        'startDate': now,
+        'endDate': new Date(now.getTime() + hourMs),
         'reason': ''
       }
     };
@@ -272,8 +275,8 @@ describe('Service: activity', function (){
       'points': 182,
       'checkinConstraint': {
         'allowed': true,
-        'startDate': '2015-09-01T00:00:00+00:00',
-        'endDate': '2015-09-01T23:59:59+00:00',
+        'startDate': now.toISOString(),
+        'endDate': (new Date(now.getTime() + hourMs)).toISOString(),
         'reason': ''
       },
       free: true,


### PR DESCRIPTION
Added option "Alle activiteiten" to the date picker for activities. When this option is picked, no "date_type" parameter is sent to the backend.