### PR TITLE
feature/UPS-1898: Adjusted membership enddate calculator to use month…

### DIFF
--- a/app/scripts/utilities/membership-end-date-calculator.factory.js
+++ b/app/scripts/utilities/membership-end-date-calculator.factory.js
@@ -29,7 +29,7 @@ function membershipEndDateCalculatorFactory(moment) {
       switch (this.association.enddateCalculation) {
         case 'BASED_ON_DATE_OF_BIRTH':
           date = moment.unix(passholder.dateOfBirth)
-            .add(this.association.enddateCalculationValidityTime, 'years')
+            .add(this.association.enddateCalculationValidityTime, 'months')
             .toDate();
 
           return {
@@ -39,7 +39,7 @@ function membershipEndDateCalculatorFactory(moment) {
 
         case 'BASED_ON_REGISTRATION_DATE':
           date = moment()
-            .add(this.association.enddateCalculationValidityTime, 'years')
+            .add(this.association.enddateCalculationValidityTime, 'months')
             .toDate();
 
           return {


### PR DESCRIPTION
The MembershipEndDateCalculator is used to calculate the end date for new registrations. 
The calculation was still happening in years.

We were not seeing this issue for existing memberships, because the end date is coming from the service itself.