### PR TITLE
UPS-4871 - In iframe, counter selecting page should never be visible

### DIFF
--- a/app/scripts/counter/ubr.counter.module.js
+++ b/app/scripts/counter/ubr.counter.module.js
@@ -26,7 +26,7 @@ angular
       params: {
         redirectTo: null
       },
-      templateUrl:'views/counter/counters.html',
+      templateUrl: isRunningInIframe() ? 'views/loading.html' : 'views/counter/counters.html',
       controller: 'CountersController',
       controllerAs: 'counters',
       resolve: {


### PR DESCRIPTION
Fixes shortly flashing counter page