### PR TITLE
UPS-5694: Fix accidental modal closure causing data loss in registration and edit forms

### DIFF
--- a/app/scripts/passholder/ubr.passholder.module.js
+++ b/app/scripts/passholder/ubr.passholder.module.js
@@ -118,6 +118,8 @@ angular
               animation: true,
               templateUrl: "views/passholder/modal-passholder-edit.html",
               size: "lg",
+              backdrop: "static",
+              keyboard: false,
               resolve: {
                 passholder: function () {
                   return passholder;

--- a/app/scripts/passholder/ubr.passholder.module.js
+++ b/app/scripts/passholder/ubr.passholder.module.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 /**
  * @ngdoc overview
@@ -9,233 +9,244 @@
  * passholder module UiTPAS Beheer
  */
 angular
-  .module('ubr.passholder', [
-    'ubr.passholder.search',
-    'ubr.passholder.bulkActions',
-    'ubr.passholder.cardUpgrade',
-    'ui.router',
-    'uitpasbeheerApp',
-    'truncate'
+  .module("ubr.passholder", [
+    "ubr.passholder.search",
+    "ubr.passholder.bulkActions",
+    "ubr.passholder.cardUpgrade",
+    "ui.router",
+    "uitpasbeheerApp",
+    "truncate",
   ])
   /* @ngInject */
   .config(function ($stateProvider) {
-
     /* @ngInject */
     function getPassholderFromStateParams(passholderService, $stateParams) {
       return passholderService.findPassholder($stateParams.identification);
     }
 
     /* @ngInject */
-    var getPassFromStateParams = function(passholderService, $stateParams) {
+    var getPassFromStateParams = function (passholderService, $stateParams) {
       return passholderService.findPass($stateParams.identification);
     };
 
     $stateProvider
-      .state('counter.main.passholder', {
-        url: 'passholder/:identification',
+      .state("counter.main.passholder", {
+        url: "passholder/:identification",
         requiresCounter: true,
         redirectOnScan: true,
         views: {
-          'content@counter': {
+          "content@counter": {
             templateProvider: function ($templateFactory, pass, $stateParams) {
-              var templatePath = 'views/split-content.html';
+              var templatePath = "views/split-content.html";
               if (pass.isBlocked($stateParams.identification)) {
-                templatePath = 'views/passholder/content-passholder-blocked.html';
-              }
-              else if (pass.kansenstatuutExpired(pass.passholder)) {
-                templatePath = 'views/passholder/content-passholder-kansenstatuut-expired.html';
+                templatePath =
+                  "views/passholder/content-passholder-blocked.html";
+              } else if (pass.kansenstatuutExpired(pass.passholder)) {
+                templatePath =
+                  "views/passholder/content-passholder-kansenstatuut-expired.html";
               }
               return $templateFactory.fromUrl(templatePath);
             },
-            controller: 'PassholderDetailController',
-            controllerAs: 'pdc'
+            controller: "PassholderDetailController",
+            controllerAs: "pdc",
           },
-          'sidebar@counter': {
-            templateUrl: 'views/passholder/sidebar-passholder-details.html',
-            controller: 'PassholderDetailController',
-            controllerAs: 'pdc'
+          "sidebar@counter": {
+            templateUrl: "views/passholder/sidebar-passholder-details.html",
+            controller: "PassholderDetailController",
+            controllerAs: "pdc",
           },
-          'top@counter.main.passholder': {
-            templateUrl: 'views/activity/content-activities.html',
-            controller: 'ActivityController',
-            controllerAs: 'ac'
+          "top@counter.main.passholder": {
+            templateUrl: "views/activity/content-activities.html",
+            controller: "ActivityController",
+            controllerAs: "ac",
           },
-          'bottom@counter.main.passholder': {
-            templateUrl: 'views/advantage/content-passholder-advantages.html',
-            controller: 'PassholderAdvantageController',
-            controllerAs: 'pac'
-          }
+          "bottom@counter.main.passholder": {
+            templateUrl: "views/advantage/content-passholder-advantages.html",
+            controller: "PassholderAdvantageController",
+            controllerAs: "pac",
+          },
         },
         params: {
-          'identification': null,
-          'destination': null,
-          'pass': null,
-          'passholder': null,
-          'advantages': null,
-          'activityMode': 'passholders',
-          'bulkSelection': null
+          identification: null,
+          destination: null,
+          pass: null,
+          passholder: null,
+          advantages: null,
+          activityMode: "passholders",
+          bulkSelection: null,
         },
         resolve: {
           pass: getPassFromStateParams,
           passholder: getPassholderFromStateParams,
           /* @ngInject */
-          advantages: function(advantageService, $stateParams, passholder) {
+          advantages: function (advantageService, $stateParams, passholder) {
             return advantageService.list(passholder.passNumber);
           },
           /* @ngInject */
           activeCounter: function (counterService) {
             return counterService.getActive();
           },
-          activityMode: function() {
-            return 'passholders';
+          activityMode: function () {
+            return "passholders";
           },
-          passholders: function() {
+          passholders: function () {
             return null;
           },
-          bulkSelection: function() {
+          bulkSelection: function () {
             return null;
           },
           /* @ngInject */
-          destination: function($stateParams) {
+          destination: function ($stateParams) {
             return $stateParams.destination || null;
-          }
-        }
+          },
+        },
       })
-      .state('counter.main.passholder.edit', {
+      .state("counter.main.passholder.edit", {
         resolve: {
           passholder: getPassholderFromStateParams,
-          identification: ['$stateParams', function($stateParams) {
-            return $stateParams.identification;
-          }]
+          identification: [
+            "$stateParams",
+            function ($stateParams) {
+              return $stateParams.identification;
+            },
+          ],
         },
         /* @ngInject */
-        onEnter: function(passholder, identification, $state, $uibModal) {
+        onEnter: function (passholder, identification, $state, $uibModal) {
           $uibModal
             .open({
               animation: true,
-              templateUrl: 'views/passholder/modal-passholder-edit.html',
-              size: 'lg',
+              templateUrl: "views/passholder/modal-passholder-edit.html",
+              size: "lg",
               resolve: {
-                passholder: function() {
+                passholder: function () {
                   return passholder;
                 },
-                identification: function() {
+                identification: function () {
                   return identification;
-                }
+                },
               },
-              controller: 'PassholderEditController',
-              controllerAs: 'pec'
+              controller: "PassholderEditController",
+              controllerAs: "pec",
             })
-            .result
-            .finally(function() {
-              $state.go('^');
+            .result.finally(function () {
+              $state.go("^");
             });
-        }
+        },
       })
-      .state('counter.main.passholder.editContact', {
+      .state("counter.main.passholder.editContact", {
         resolve: {
           passholder: getPassholderFromStateParams,
-          identification: ['$stateParams', function($stateParams) {
-            return $stateParams.identification;
-          }]
+          identification: [
+            "$stateParams",
+            function ($stateParams) {
+              return $stateParams.identification;
+            },
+          ],
         },
         /* @ngInject */
-        onEnter: function(passholder, identification, $state, $uibModal) {
+        onEnter: function (passholder, identification, $state, $uibModal) {
           $uibModal
             .open({
               animation: true,
-              templateUrl: 'views/passholder/modal-passholder-edit-contact.html',
-              size: 'sm',
+              templateUrl:
+                "views/passholder/modal-passholder-edit-contact.html",
+              size: "sm",
               resolve: {
-                passholder: function() {
+                passholder: function () {
                   return passholder;
                 },
-                identification: function() {
+                identification: function () {
                   return passholder.passNumber;
-                }
+                },
               },
-              controller: 'PassholderEditController',
-              controllerAs: 'pec'
+              controller: "PassholderEditController",
+              controllerAs: "pec",
             })
-            .result
-            .finally(function() {
-              $state.go('^');
+            .result.finally(function () {
+              $state.go("^");
             });
-        }
+        },
       })
-      .state('counter.main.passholder.pointHistory', {
+      .state("counter.main.passholder.pointHistory", {
         params: {
           pass: null,
-          passholder: null
+          passholder: null,
         },
         resolve: {
           pass: getPassFromStateParams,
-          passholder: getPassholderFromStateParams
+          passholder: getPassholderFromStateParams,
         },
         /* @ngInject */
-        onEnter: function(pass, passholder, $state, $uibModal) {
+        onEnter: function (pass, passholder, $state, $uibModal) {
           $uibModal
             .open({
               animation: true,
-              templateUrl: 'views/passholder/modal-passholder-checkins.html',
-              size: 'sm',
+              templateUrl: "views/passholder/modal-passholder-checkins.html",
+              size: "sm",
               resolve: {
-                pass: function() {
+                pass: function () {
                   return pass;
                 },
-                passholder: function() {
+                passholder: function () {
                   return passholder;
-                }
+                },
               },
-              controller: 'PointHistoryController',
-              controllerAs: 'phc'
+              controller: "PointHistoryController",
+              controllerAs: "phc",
             })
-            .result
-            .finally(function() {
-              $state.go('^');
+            .result.finally(function () {
+              $state.go("^");
             });
-        }
+        },
       })
-      .state('counter.main.passholder.replacePass', {
+      .state("counter.main.passholder.replacePass", {
         resolve: {
           passholder: getPassholderFromStateParams,
-          pass: getPassFromStateParams
+          pass: getPassFromStateParams,
         },
         params: {
-          'justBlocked': false
+          justBlocked: false,
         },
-        url: '/replace-pass',
+        url: "/replace-pass",
         /* @ngInject */
-        onEnter: function(passholder, pass, $state, $uibModal, $stateParams) {
+        onEnter: function (passholder, pass, $state, $uibModal, $stateParams) {
           $uibModal
             .open({
               animation: true,
-              templateUrl: 'views/passholder/modal-passholder-replace-card.html',
-              size: 'sm',
+              templateUrl:
+                "views/passholder/modal-passholder-replace-card.html",
+              size: "sm",
               resolve: {
-                passholder: function() {
+                passholder: function () {
                   return passholder;
                 },
-                pass: function() {
+                pass: function () {
                   return pass;
-                }
+                },
               },
-              controller: 'PassholderReplacePassController',
-              controllerAs: 'rpc'
+              controller: "PassholderReplacePassController",
+              controllerAs: "rpc",
             })
-            .result
-            .then(function (newPassNumber) {
-              $state.go('counter.main.passholder', {identification: newPassNumber}, {reload: true});
-            }, function () {
-              if ($stateParams.justBlocked) {
-                $state.go('^', {}, {reload: true});
-              } else {
-                $state.go('^');
+            .result.then(
+              function (newPassNumber) {
+                $state.go(
+                  "counter.main.passholder",
+                  { identification: newPassNumber },
+                  { reload: true }
+                );
+              },
+              function () {
+                if ($stateParams.justBlocked) {
+                  $state.go("^", {}, { reload: true });
+                } else {
+                  $state.go("^");
+                }
               }
-            });
-        }
+            );
+        },
       })
-      .state('counter.main.passholder.blockPass', {
+      .state("counter.main.passholder.blockPass", {
         params: {
           pass: null,
           passholder: null,
@@ -244,68 +255,76 @@ angular
         resolve: {
           pass: getPassFromStateParams,
           passholder: getPassholderFromStateParams,
-          selectedUitpas: ['$stateParams', function($stateParams) {
-            return $stateParams.selectedUitpas;
-          }],
+          selectedUitpas: [
+            "$stateParams",
+            function ($stateParams) {
+              return $stateParams.selectedUitpas;
+            },
+          ],
         },
         /* @ngInject */
-        onEnter: function(pass, passholder, selectedUitpas, $state, $uibModal) {
+        onEnter: function (
+          pass,
+          passholder,
+          selectedUitpas,
+          $state,
+          $uibModal
+        ) {
           $uibModal
             .open({
               animation: true,
-              templateUrl: 'views/passholder/modal-passholder-block-pass.html',
-              size: 'sm',
+              templateUrl: "views/passholder/modal-passholder-block-pass.html",
+              size: "sm",
               resolve: {
-                pass: function() {
+                pass: function () {
                   return pass;
                 },
-                passholder: function() {
+                passholder: function () {
                   return passholder;
                 },
-                selectedUitpas: function() {
+                selectedUitpas: function () {
                   return selectedUitpas;
-                }
+                },
               },
-              controller: 'PassholderBlockPassController',
-              controllerAs: 'pbp'
+              controller: "PassholderBlockPassController",
+              controllerAs: "pbp",
             })
-            .result
-            .finally(function() {
-              $state.go('^');
+            .result.finally(function () {
+              $state.go("^");
             });
-        }
+        },
       })
-      .state('counter.main.passholder.ticketSales', {
+      .state("counter.main.passholder.ticketSales", {
         params: {
           pass: null,
-          passholder: null
+          passholder: null,
         },
         resolve: {
           pass: getPassFromStateParams,
-          passholder: getPassholderFromStateParams
+          passholder: getPassholderFromStateParams,
         },
         /* @ngInject */
-        onEnter: function(pass, passholder, $state, $uibModal) {
+        onEnter: function (pass, passholder, $state, $uibModal) {
           $uibModal
             .open({
               animation: true,
-              templateUrl: 'views/passholder/modal-passholder-ticket-sales.html',
-              size: 'sm',
+              templateUrl:
+                "views/passholder/modal-passholder-ticket-sales.html",
+              size: "sm",
               resolve: {
-                pass: function() {
+                pass: function () {
                   return pass;
                 },
-                passholder: function() {
+                passholder: function () {
                   return passholder;
-                }
+                },
               },
-              controller: 'TicketSalesController',
-              controllerAs: 'tsc'
+              controller: "TicketSalesController",
+              controllerAs: "tsc",
             })
-            .result
-            .finally(function() {
-              $state.go('^');
+            .result.finally(function () {
+              $state.go("^");
             });
-      }
-    });
+        },
+      });
   });

--- a/app/scripts/registration/ubr.registration.module.js
+++ b/app/scripts/registration/ubr.registration.module.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 /**
  * @ngdoc overview
@@ -9,141 +9,149 @@
  * registration module UiTPAS Beheer
  */
 angular
-  .module('ubr.registration', [
-    'ui.router',
-    'uitpasbeheerApp'
-  ])
+  .module("ubr.registration", ["ui.router", "uitpasbeheerApp"])
   /* @ngInject */
   .config(function ($stateProvider) {
-
-    var getPassFromStateParams = function(passholderService, $stateParams) {
+    var getPassFromStateParams = function (passholderService, $stateParams) {
       if ($stateParams.pass) {
         return $stateParams.pass;
-      }
-      else {
+      } else {
         return passholderService.findPass($stateParams.identification);
       }
     };
 
     var registrationModalInstance;
 
-    redirectOnScan.$inject = ['UiTPASRouter'];
+    redirectOnScan.$inject = ["UiTPASRouter"];
     function redirectOnScan(UiTPASRouter) {
       UiTPASRouter.redirectOnScanEnabled();
     }
 
     $stateProvider
-      .state('counter.main.register', {
-        url: 'passholder/:identification/register',
+      .state("counter.main.register", {
+        url: "passholder/:identification/register",
         requiresCounter: true,
         redirectOnScan: true,
         onEnter: redirectOnScan,
         params: {
           pass: null,
-          identification: null
+          identification: null,
         },
         resolve: {
-          pass: ['passholderService', '$stateParams', getPassFromStateParams],
-          identification: ['$stateParams', function($stateParams) {
-            return $stateParams.identification;
-          }],
-          activeCounter: ['counterService', function (counterService) {
-            return counterService.getActive();
-          }]
+          pass: ["passholderService", "$stateParams", getPassFromStateParams],
+          identification: [
+            "$stateParams",
+            function ($stateParams) {
+              return $stateParams.identification;
+            },
+          ],
+          activeCounter: [
+            "counterService",
+            function (counterService) {
+              return counterService.getActive();
+            },
+          ],
         },
         views: {
-          'content@counter': {
-            templateUrl: 'views/registration/content-passholder-register.html',
-            controller: 'PassholderRegisterController',
-            controllerAs: 'prc'
+          "content@counter": {
+            templateUrl: "views/registration/content-passholder-register.html",
+            controller: "PassholderRegisterController",
+            controllerAs: "prc",
           },
-          'sidebar@counter': {
-            templateUrl: 'views/registration/sidebar-passholder-register.html',
-            controller: 'PassholderRegisterController',
-            controllerAs: 'prc'
-          }
-        }
+          "sidebar@counter": {
+            templateUrl: "views/registration/sidebar-passholder-register.html",
+            controller: "PassholderRegisterController",
+            controllerAs: "prc",
+          },
+        },
       })
-      .state('counter.main.register.form', {
+      .state("counter.main.register.form", {
         abstract: true,
         resolve: {
-          pass: ['passholderService', '$stateParams', getPassFromStateParams],
-          activeCounter: ['counterService', function (counterService) {
-            return counterService.getActive();
-          }]
-        },
-        onEnter : ['pass', 'activeCounter', '$state', '$uibModal', function(pass, activeCounter, $state, $uibModal) {
-          registrationModalInstance = $uibModal.open({
-            animation: true,
-            templateUrl: 'views/registration/multi-step-form.html',
-            size: 'lg',
-            resolve: {
-              pass: function() {
-                return pass;
-              },
-              activeCounter: function() {
-                return activeCounter;
-              }
+          pass: ["passholderService", "$stateParams", getPassFromStateParams],
+          activeCounter: [
+            "counterService",
+            function (counterService) {
+              return counterService.getActive();
             },
-            controller: 'RegistrationModalController',
-            controllerAs: 'prc'
-          });
-
-          function passholderRegistered() {
-            $state.go('counter.main.passholder', {
-              identification: pass.number,
-              destination: {
-                route: 'counter.main',
-                params: {}
+          ],
+        },
+        onEnter: [
+          "pass",
+          "activeCounter",
+          "$state",
+          "$uibModal",
+          function (pass, activeCounter, $state, $uibModal) {
+            registrationModalInstance = $uibModal.open({
+              animation: true,
+              templateUrl: "views/registration/multi-step-form.html",
+              size: "lg",
+              resolve: {
+                pass: function () {
+                  return pass;
+                },
+                activeCounter: function () {
+                  return activeCounter;
+                },
               },
+              controller: "RegistrationModalController",
+              controllerAs: "prc",
             });
-          }
 
-          registrationModalInstance
-            .result
-            .then(passholderRegistered);
-        }]
+            function passholderRegistered() {
+              $state.go("counter.main.passholder", {
+                identification: pass.number,
+                destination: {
+                  route: "counter.main",
+                  params: {},
+                },
+              });
+            }
+
+            registrationModalInstance.result.then(passholderRegistered);
+          },
+        ],
       })
-      .state('counter.main.register.form.personalData', {
-        url: '/personal-info',
+      .state("counter.main.register.form.personalData", {
+        url: "/personal-info",
         views: {
-          'registrationStep@': {
-            templateUrl: 'views/registration/personal-data-step.html'
-          }
+          "registrationStep@": {
+            templateUrl: "views/registration/personal-data-step.html",
+          },
         },
         params: {
-          'pass': null,
-          'kansenstatuut': null,
-          'school': null,
-          'registerForeign': null
+          pass: null,
+          kansenstatuut: null,
+          school: null,
+          registerForeign: null,
         },
-        stepNumber: 1
+        stepNumber: 1,
       })
-      .state('counter.main.register.form.contactData', {
-        url: '/contact-info',
+      .state("counter.main.register.form.contactData", {
+        url: "/contact-info",
         views: {
-          'registrationStep@': {
-            templateUrl: 'views/registration/contact-data-step.html'
-          }
+          "registrationStep@": {
+            templateUrl: "views/registration/contact-data-step.html",
+          },
         },
-        stepNumber: 2
+        stepNumber: 2,
       })
-      .state('counter.main.register.form.optIns', {
-        url: '/opt-ins',
+      .state("counter.main.register.form.optIns", {
+        url: "/opt-ins",
         views: {
-          'registrationStep@': {
-            templateUrl: 'views/registration/opt-ins-data-step.html'
-          }
+          "registrationStep@": {
+            templateUrl: "views/registration/opt-ins-data-step.html",
+          },
         },
-        stepNumber: 3
+        stepNumber: 3,
       })
-      .state('counter.main.register.form.price', {
-        url: '/price',
+      .state("counter.main.register.form.price", {
+        url: "/price",
         views: {
-          'registrationStep@': {
-            templateUrl: 'views/registration/price-data-step.html'
-          }
+          "registrationStep@": {
+            templateUrl: "views/registration/price-data-step.html",
+          },
         },
-        stepNumber: 4
+        stepNumber: 4,
       });
   });

--- a/app/scripts/registration/ubr.registration.module.js
+++ b/app/scripts/registration/ubr.registration.module.js
@@ -86,6 +86,8 @@ angular
               animation: true,
               templateUrl: "views/registration/multi-step-form.html",
               size: "lg",
+              backdrop: "static",
+              keyboard: false,
               resolve: {
                 pass: function () {
                   return pass;


### PR DESCRIPTION
### Problem
Users were losing their form data when accidentally clicking outside of modals during:
- Multi-step passholder registration process
- Passholder information editing

This happened because the modals would close on backdrop click or ESC key press, causing frustration and requiring users to re-enter all their data.

### Solution
Added modal configuration options to prevent accidental closure:
- `backdrop: 'static'` - Prevents closing when clicking outside the modal
- `keyboard: false` - Prevents closing with the ESC key

### Files Changed
- `app/scripts/registration/ubr.registration.module.js` - Registration modal protection
- `app/scripts/passholder/ubr.passholder.module.js` - Edit passholder modal protection

### Result
Users can now only close these critical modals through:
- Clicking the close button (×) in the modal header
- Successfully completing the form submission
- Using explicit cancel/back functionality

This prevents accidental data loss and improves the user experience during form completion.

Ticket: https://jira.publiq.be/browse/UPS-5694